### PR TITLE
Fix missing Bills icon

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,6 +72,6 @@ export const CATEGORY_ICONS: Record<ExpenseCategory, string> = {
   Transportation: '🚗',
   Entertainment: '🎬',
   Shopping: '🛍️',
-  Bills: '��',
+  Bills: '📄',
   Other: '📝'
 };


### PR DESCRIPTION
## Icon Fix

This PR addresses only one specific UI issue:

### Fixed Missing Bills Icon
- Fixed the missing Bills icon in the category list
- The icon was displaying as '��' and is now replaced with '📄'
- This ensures all category icons display correctly in the expense list and dashboard

### Testing Done
- Verified all category icons display correctly

This is a minimal fix that addresses just the icon issue without any other changes.